### PR TITLE
Replace Ownable with AccessControl 

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -10,7 +10,7 @@ contract Vault is AccessControl {
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
     /*
-     *
+     * Assigns the DEFAULT_ADMIN_ROLE to `_admin` and MANAGER_ROLE to each one of the `users` specified
      */
     constructor (address _admin, address[] memory users) public {
         _setupRole(DEFAULT_ADMIN_ROLE, _admin);

--- a/test/Vault.test.js
+++ b/test/Vault.test.js
@@ -39,6 +39,12 @@ describe('Vault', function () {
         expect(await vault.hasRole(MANAGER_ROLE, managerAddr)).to.be.true
     })
 
+    it('Allows adding other managers', async function () {
+        await vault.connect(admin).grantRole(MANAGER_ROLE, userAddr)
+
+        expect(await vault.hasRole(MANAGER_ROLE, userAddr)).to.be.true
+    })
+
     describe('Deposit', function () {
         it('Reverts if not executed by owner', async function () {
             await expect(

--- a/test/Vault.test.js
+++ b/test/Vault.test.js
@@ -6,21 +6,23 @@ const BN = ethers.BigNumber
 describe('Vault', function () {
     let vault
     let erc20Mock
-    let owner, user
-    let ownerAddr, userAddr
+    let admin, manager, user
+    let adminAddr, managerAddr, userAddr
+
+    const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000'
+    const MANAGER_ROLE = ethers.utils.solidityKeccak256(['string'], ['MANAGER_ROLE'])
+
     const amount = BN.from(100).mul(BN.from(10).pow(18))
 
     beforeEach(async function () {
-        const [creator, ownerSigner, userSigner] = await ethers.getSigners()
-        owner = ownerSigner
-        ownerAddr = await owner.getAddress()
-
-        user = userSigner
+        [admin, manager, user] = await ethers.getSigners()
+        adminAddr = await admin.getAddress()
+        managerAddr = await manager.getAddress()
         userAddr = await user.getAddress()
 
-        const Vault = await ethers.getContractFactory('Vault', creator)
+        const Vault = await ethers.getContractFactory('Vault', admin)
 
-        vault = await Vault.deploy(await ownerSigner.getAddress())
+        vault = await Vault.deploy(adminAddr, [managerAddr])
         await vault.deployed()
 
         const ERC20Mock = await ethers.getContractFactory('ERC20Mock')
@@ -32,20 +34,21 @@ describe('Vault', function () {
         expect(vault.address).to.not.equal(0)
     })
 
-    it('Transfers ownership to address provided', async function () {
-        expect(await vault.owner()).to.equal(ownerAddr)
+    it('Sets up correct access-control roles', async function () {
+        expect(await vault.hasRole(DEFAULT_ADMIN_ROLE, adminAddr)).to.be.true
+        expect(await vault.hasRole(MANAGER_ROLE, managerAddr)).to.be.true
     })
 
     describe('Deposit', function () {
         it('Reverts if not executed by owner', async function () {
             await expect(
                 vault.deposit(userAddr, erc20Mock.address, 100),
-            ).to.be.revertedWith('Ownable: caller is not the owner')
+            ).to.be.revertedWith('Vault: caller is not vault manager')
         })
 
         it('Reverts if amount is <= 0', async function () {
             await expect(
-                vault.connect(owner).deposit(userAddr, erc20Mock.address, 0),
+                vault.connect(manager).deposit(userAddr, erc20Mock.address, 0),
             ).to.be.revertedWith('Vault: Amount must be > 0')
         })
 
@@ -54,7 +57,7 @@ describe('Vault', function () {
             // no allowance
 
             await expect(
-                vault.connect(owner).deposit(userAddr, erc20Mock.address, amount),
+                vault.connect(manager).deposit(userAddr, erc20Mock.address, amount),
             ).to.be.revertedWith('Vault: Token allowance too small')
         })
 
@@ -62,7 +65,7 @@ describe('Vault', function () {
             await erc20Mock.mint(userAddr, amount)
             await erc20Mock.connect(user).approve(vault.address, amount)
 
-            await vault.connect(owner).deposit(userAddr, erc20Mock.address, amount)
+            await vault.connect(manager).deposit(userAddr, erc20Mock.address, amount)
 
             const balance = await vault.balanceOf(userAddr, erc20Mock.address)
 
@@ -73,7 +76,7 @@ describe('Vault', function () {
             await erc20Mock.mint(userAddr, amount)
             await erc20Mock.connect(user).approve(vault.address, amount)
 
-            await vault.connect(owner).deposit(userAddr, erc20Mock.address, amount)
+            await vault.connect(manager).deposit(userAddr, erc20Mock.address, amount)
 
             expect(await erc20Mock.transferFromCalled()).to.be.true
         })
@@ -83,12 +86,12 @@ describe('Vault', function () {
         it('Reverts if not executed by owner', async function () {
             await expect(
                 vault.withdraw(erc20Mock.address, userAddr),
-            ).to.be.revertedWith('Ownable: caller is not the owner')
+            ).to.be.revertedWith('Vault: caller is not vault manager')
         })
 
         it('Reverts if user has no balance', async function () {
             await expect(
-                vault.connect(owner).withdraw(erc20Mock.address, userAddr),
+                vault.connect(manager).withdraw(erc20Mock.address, userAddr),
             ).to.be.revertedWith('Vault: User has empty balance')
         })
 
@@ -96,10 +99,10 @@ describe('Vault', function () {
             // set-up the balance sheet
             await erc20Mock.mint(userAddr, amount)
             await erc20Mock.connect(user).approve(vault.address, amount)
-            await vault.connect(owner).deposit(userAddr, erc20Mock.address, amount)
+            await vault.connect(manager).deposit(userAddr, erc20Mock.address, amount)
 
             // call withdraw
-            await vault.connect(owner).withdraw(userAddr, erc20Mock.address)
+            await vault.connect(manager).withdraw(userAddr, erc20Mock.address)
 
             const balance = await vault.balanceOf(userAddr, erc20Mock.address)
 
@@ -110,10 +113,10 @@ describe('Vault', function () {
             // set-up the balance sheet
             await erc20Mock.mint(userAddr, amount)
             await erc20Mock.connect(user).approve(vault.address, amount)
-            await vault.connect(owner).deposit(userAddr, erc20Mock.address, amount)
+            await vault.connect(manager).deposit(userAddr, erc20Mock.address, amount)
 
             // call withdraw
-            await vault.connect(owner).withdraw(userAddr, erc20Mock.address)
+            await vault.connect(manager).withdraw(userAddr, erc20Mock.address)
 
             expect(await erc20Mock.transferCalled()).to.be.true
             expect(await erc20Mock.transferRecipient()).to.be.equal(userAddr)


### PR DESCRIPTION
In order to allow multiple contracts to call the functions on the Vault, we have to replace `Ownable` (which only allows one owner) with a role-based approach which is already implemented in the `AccessControl` abstract contract from OpenZeppelin.

The `DEFAULT_ADMIN_ROLE` is the only role that can grant or revoke roles to accounts.
My proposal is to assign this role to the DAO.

The `MANAGER_ROLE` is the only one that can execute the `deposit` and `withdraw` functions. 